### PR TITLE
Fix version detection when file is opened.

### DIFF
--- a/src/Document/Document.cpp
+++ b/src/Document/Document.cpp
@@ -899,6 +899,7 @@ int Document::versionFromFile (QFile *file) const
   LOG4CPP_INFO_S ((*mainCat)) << "Document::versionFromFile";
 
   int version = VERSION_6; // Use default if tag is missing
+  QString version_string = QString::number(VERSION_6);
 
   QDomDocument doc;
   if (doc.setContent (file)) {
@@ -907,7 +908,7 @@ int Document::versionFromFile (QFile *file) const
     if (nodes.count() > 0) {
       QDomNode node = nodes.at (0);
       QDomElement elem = node.toElement();
-      version = (int) elem.attribute (DOCUMENT_SERIALIZE_APPLICATION_VERSION_NUMBER).toDouble();
+      version = (int) elem.attribute (DOCUMENT_SERIALIZE_APPLICATION_VERSION_NUMBER, version_string).toDouble();
     }
   }
 


### PR DESCRIPTION
I tried open a file from https://github.com/markummitchell/engauge6/issues/63 in freshly built master, and it failed. 
![untitled4](https://cloud.githubusercontent.com/assets/33132/13204010/9f1a5536-d8e6-11e5-808a-8a539b6fec53.png)
According to https://doc.qt.io/qt-5/qdomelement.html#attribute one must specify default return value if requested attribute not found.