### PR TITLE
Organize msvc windows builds.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,32 @@
+init:
+  - C:\"Program Files (x86)"\"Microsoft Visual Studio 12.0"\VC\vcvarsall.bat x86
+
+install:
+  - set QTDIR=C:\Qt\5.5\msvc2013
+  - set PATH=%PATH%;%QTDIR%\bin
+  - cd C:\projects\engauge6
+  - curl -fsSLO 'https://dl.dropboxusercontent.com/u/1147076/log4cpp-1.1.1.zip'
+  - 7z x log4cpp-1.1.1.zip -aoa
+  - mkdir fftw-3.3.4-dll32
+  - cd fftw-3.3.4-dll32
+  - curl -fsSLO 'ftp://ftp.fftw.org/pub/fftw/fftw-3.3.4-dll32.zip'
+  - 7z x fftw-3.3.4-dll32.zip -aoa
+  - lib /def:libfftw3-3.def
+  - lib /def:libfftw3f-3.def
+  - lib /def:libfftw3l-3.def
+  - mkdir include
+  - mkdir lib
+  - move fftw3.h include
+  - move *dll lib
+  - move *def lib
+  - move *lib lib
+
+build_script:
+  - cd C:\projects\engauge6
+  - set ENGAUGE_RELEASE=1
+  - set LOG4CPP_HOME=C:\projects\engauge6\log4cpp-1.1.1
+  - set FFTW_HOME=C:\projects\engauge6\fftw-3.3.4-dll32
+  - qmake engauge.pro
+  - move Makefile Makefile.orig
+  - ps: gc Makefile.orig | %{ $_ -replace '551.lib', '.lib' } > Makefile
+  - nmake

--- a/engauge.pro
+++ b/engauge.pro
@@ -543,7 +543,9 @@ win32-msvc* {
 QMAKE_CXXFLAGS += -EHsc
 LIBS += $$(FFTW_HOME)/lib/libfftw3-3.lib $$(LOG4CPP_HOME)/lib/log4cpp.lib shell32.lib
 } else {
+win32-g++* {
 LIBS += -L$$(LOG4CPP_HOME)/lib -L$$(FFTW_HOME)/lib
+}
 LIBS += -llog4cpp -lfftw3
 }
 

--- a/engauge.pro
+++ b/engauge.pro
@@ -26,7 +26,9 @@ CONFIG -= debug
 # 2) Full coverage requires disabling of ENGAUGE_ASSERT by setting QT_NO_DEBUG
 # 3) -Wuninitialized requires O1, O2 or O3 optimization
 DEFINES += QT_NO_DEBUG
+*-g++* {
 QMAKE_CXXFLAGS_WARN_ON += -Wreturn-type -O1 -Wuninitialized -Wunused-variable
+}
 }
 
 OBJECTS_DIR = src/.objs
@@ -533,11 +535,17 @@ TARGET = bin/engauge
 
 QT += core gui network printsupport widgets xml help
 
-win32-g++* {
+win32-* {
 CONFIG += windows
-LIBS += -L$$(LOG4CPP_HOME)/lib -L$$(FFTW_HOME)/lib
 }
+
+win32-msvc* {
+QMAKE_CXXFLAGS += -EHsc
+LIBS += $$(FFTW_HOME)/lib/libfftw3-3.lib $$(LOG4CPP_HOME)/lib/log4cpp.lib shell32.lib
+} else {
+LIBS += -L$$(LOG4CPP_HOME)/lib -L$$(FFTW_HOME)/lib
 LIBS += -llog4cpp -lfftw3
+}
 
 INCLUDEPATH += src \
                src/Background \
@@ -582,7 +590,7 @@ INCLUDEPATH += src \
                src/View \
                src/Zoom
 
-win32-g++* {
+win32-* {
 INCLUDEPATH += $$(FFTW_HOME)/include \
                $$(LOG4CPP_HOME)/include
 }


### PR DESCRIPTION
Goal: Organize CI via native builds on Windows on Appveyor service.
Tested with VS 2013 CE and Qt 5.5.1 32-bit msvc.